### PR TITLE
Split socket code from OTA into extra componnent

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -220,6 +220,7 @@ esphome/components/nfc/* @jesserockz
 esphome/components/noblex/* @AGalfra
 esphome/components/number/* @esphome/core
 esphome/components/ota/* @esphome/core
+esphome/components/ota_socket/* @esphome/core
 esphome/components/output/* @esphome/core
 esphome/components/pca6416a/* @Mat931
 esphome/components/pca9554/* @clydebarrow @hwstar

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -321,7 +321,7 @@ def upload_program(config, args, host):
     from esphome import espota2
 
     ota_conf = config[CONF_OTA]
-    remote_port = ota_conf[CONF_PORT]
+    remote_port = config["ota_socket"][CONF_PORT]
     password = ota_conf.get(CONF_PASSWORD, "")
 
     if (
@@ -374,7 +374,7 @@ def download_program(config, args):
 
     ota_conf = config[CONF_OTA]
     host = CORE.address
-    remote_port = ota_conf[CONF_PORT]
+    remote_port = config["ota_socket"][CONF_PORT]
     password = ota_conf.get(CONF_PASSWORD, "")
 
     bin_type = espota2.OTAPartitionType
@@ -406,7 +406,7 @@ def upload_factory_ota(config, args):
 
     ota_conf = config[CONF_OTA]
     host = CORE.address
-    remote_port = ota_conf[CONF_PORT]
+    remote_port = config["ota_socket"][CONF_PORT]
     password = ota_conf.get(CONF_PASSWORD, "")
 
     if (

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -6,7 +6,6 @@ from esphome.const import (
     CONF_ID,
     CONF_NUM_ATTEMPTS,
     CONF_PASSWORD,
-    CONF_PORT,
     CONF_REBOOT_TIMEOUT,
     CONF_SAFE_MODE,
     CONF_TRIGGER_ID,
@@ -16,8 +15,7 @@ from esphome.const import (
 from esphome.core import CORE, coroutine_with_priority
 
 CODEOWNERS = ["@esphome/core"]
-DEPENDENCIES = ["network"]
-AUTO_LOAD = ["socket", "md5"]
+AUTO_LOAD = ["md5"]
 
 CONF_UNPROTECTED_WRITES = "unprotected_writes"
 CONF_ON_STATE_CHANGE = "on_state_change"
@@ -51,14 +49,6 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(OTAComponent),
             cv.Optional(CONF_SAFE_MODE, default=False): cv.boolean,
             cv.Optional(CONF_UNPROTECTED_WRITES, default=False): cv.boolean,
-            cv.SplitDefault(
-                CONF_PORT,
-                esp8266=8266,
-                esp32=3232,
-                rp2040=2040,
-                bk72xx=8892,
-                rtl87xx=8892,
-            ): cv.port,
             cv.Optional(CONF_PASSWORD): cv.string,
             cv.Optional(
                 CONF_REBOOT_TIMEOUT, default="5min"
@@ -102,7 +92,6 @@ async def to_code(config):
     CORE.data[CONF_OTA] = {}
 
     var = cg.new_Pvariable(config[CONF_ID])
-    cg.add(var.set_port(config[CONF_PORT]))
     cg.add_define("USE_OTA")
     if CONF_PASSWORD in config:
         cg.add(var.set_auth_password(config[CONF_PASSWORD]))

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -15,7 +15,7 @@ from esphome.const import (
 from esphome.core import CORE, coroutine_with_priority
 
 CODEOWNERS = ["@esphome/core"]
-AUTO_LOAD = ["md5"]
+AUTO_LOAD = ["md5", "ota_socket"]
 
 CONF_UNPROTECTED_WRITES = "unprotected_writes"
 CONF_ON_STATE_CHANGE = "on_state_change"

--- a/esphome/components/ota/ota_component.cpp
+++ b/esphome/components/ota/ota_component.cpp
@@ -67,10 +67,10 @@ void OTAComponent::loop() {
   }
 }
 
-void OTAComponent::do_OTA_session(OTAFrontend *frontend) {
-  if (this->activeFrontend_ != nullptr) {
+void OTAComponent::do_ota_session(OTAFrontend *frontend) {
+  if (this->active_frontend_ != nullptr) {
   } else {
-    activeFrontend_ = frontend;
+    active_frontend_ = frontend;
   }
 
   this->handle_();
@@ -240,16 +240,16 @@ void OTAComponent::handle_() {
         case OTA_COMMAND_REBOOT:
           buf[0] = OTA_RESPONSE_OK;
           this->writeall_(buf, 1);
-          this->activeFrontend_->closeSession();
-          this->activeFrontend_ = nullptr;
+          this->active_frontend_->close_session();
+          this->active_frontend_ = nullptr;
           delay(100);  // NOLINT
           App.safe_reboot();
           return;  // Will never be reached
         case OTA_COMMAND_END:
           ESP_LOGI(TAG, "OTA session finished!");
           // close connection
-          this->activeFrontend_->closeSession();
-          this->activeFrontend_ = nullptr;
+          this->active_frontend_->close_session();
+          this->active_frontend_ = nullptr;
           return;
         case OTA_COMMAND_READ:
           error_code = this->get_partition_info_(buf, bin_type, ota_size);
@@ -286,8 +286,8 @@ void OTAComponent::handle_() {
     this->readall_(buf, 1);
 
     // close connection and reboot
-    this->activeFrontend_->closeSession();
-    this->activeFrontend_ = nullptr;
+    this->active_frontend_->close_session();
+    this->active_frontend_ = nullptr;
     delay(100);  // NOLINT
     App.safe_reboot();
     return;  // Will never be reached
@@ -313,7 +313,7 @@ bool OTAComponent::readall_(uint8_t *buf, size_t len) {
       return false;
     }
 
-    ssize_t read = this->activeFrontend_->read(buf + at, len - at);
+    ssize_t read = this->active_frontend_->read(buf + at, len - at);
     if (read == -1) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
         App.feed_wdt();
@@ -344,7 +344,7 @@ bool OTAComponent::writeall_(const uint8_t *buf, size_t len) {
       return false;
     }
 
-    ssize_t written = this->activeFrontend_->write(buf + at, len - at);
+    ssize_t written = this->active_frontend_->write(buf + at, len - at);
     if (written == -1) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
         App.feed_wdt();
@@ -431,7 +431,7 @@ OTAResponseTypes OTAComponent::write_flash_(uint8_t *buf, std::unique_ptr<OTABac
   while (total < ota_size) {
     // TODO: timeout check
     size_t requested = std::min(sizeof(buf), ota_size - total);
-    ssize_t read = this->activeFrontend_->read(buf, requested);
+    ssize_t read = this->active_frontend_->read(buf, requested);
     if (read == -1) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
         App.feed_wdt();

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "esphome/components/socket/socket.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/defines.h"
 #include "ota_backend.h"
+#include "ota_frontend.h"
 
 namespace esphome {
 namespace ota {
@@ -38,9 +39,6 @@ class OTAComponent : public Component {
   void set_auth_password(const std::string &password) { password_ = password; }
 #endif  // USE_OTA_PASSWORD
 
-  /// Manually set the port OTA should listen on.
-  void set_port(uint16_t port);
-
   bool should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_time);
 
   /// Set to true if the next startup will enter safe mode
@@ -51,14 +49,16 @@ class OTAComponent : public Component {
   void add_on_state_callback(std::function<void(OTAState, float, uint8_t)> &&callback);
 #endif
 
+  // Starts an OTA session using passed frontend to send/receive bytes
+  // Only one session can be done at the same time
+  void do_OTA_session(OTAFrontend *frontend);
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
   void loop() override;
-
-  uint16_t get_port() const;
 
   void clean_rtc();
 
@@ -81,10 +81,7 @@ class OTAComponent : public Component {
   std::string password_;
 #endif  // USE_OTA_PASSWORD
 
-  uint16_t port_;
-
-  std::unique_ptr<socket::Socket> server_;
-  std::unique_ptr<socket::Socket> client_;
+  OTAFrontend *activeFrontend_{nullptr};
 
   bool has_safe_mode_{false};              ///< stores whether safe mode can be enabled.
   uint32_t safe_mode_start_time_;          ///< stores when safe mode was enabled.

--- a/esphome/components/ota/ota_component.h
+++ b/esphome/components/ota/ota_component.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "esphome/core/defines.h"
 #include "esphome/core/component.h"
-#include "esphome/core/preferences.h"
-#include "esphome/core/helpers.h"
 #include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/preferences.h"
 #include "ota_backend.h"
 #include "ota_frontend.h"
 
@@ -51,7 +50,7 @@ class OTAComponent : public Component {
 
   // Starts an OTA session using passed frontend to send/receive bytes
   // Only one session can be done at the same time
-  void do_OTA_session(OTAFrontend *frontend);
+  void do_ota_session(OTAFrontend *frontend);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -81,7 +80,7 @@ class OTAComponent : public Component {
   std::string password_;
 #endif  // USE_OTA_PASSWORD
 
-  OTAFrontend *activeFrontend_{nullptr};
+  OTAFrontend *active_frontend_{nullptr};
 
   bool has_safe_mode_{false};              ///< stores whether safe mode can be enabled.
   uint32_t safe_mode_start_time_;          ///< stores when safe mode was enabled.

--- a/esphome/components/ota/ota_frontend.h
+++ b/esphome/components/ota/ota_frontend.h
@@ -8,7 +8,7 @@ class OTAFrontend {
   virtual ~OTAFrontend() = default;
   virtual ssize_t read(uint8_t *buf, size_t len);
   virtual ssize_t write(const uint8_t *buf, size_t len);
-  virtual void closeSession();
+  virtual void close_session();
 };
 
 }  // namespace ota

--- a/esphome/components/ota/ota_frontend.h
+++ b/esphome/components/ota/ota_frontend.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace esphome {
+namespace ota {
+
+class OTAFrontend {
+ public:
+  virtual ~OTAFrontend() = default;
+  virtual ssize_t read(uint8_t *buf, size_t len);
+  virtual ssize_t write(const uint8_t *buf, size_t len);
+  virtual void closeSession();
+};
+
+}  // namespace ota
+}  // namespace esphome

--- a/esphome/components/ota_socket/__init__.py
+++ b/esphome/components/ota_socket/__init__.py
@@ -1,0 +1,37 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_PORT,
+)
+
+CODEOWNERS = ["@esphome/core"]
+DEPENDENCIES = ["network"]
+AUTO_LOAD = ["socket", "ota"]
+
+ota_ns = cg.esphome_ns.namespace("ota_socket")
+OTAComponent = ota_ns.class_("OTAFrontendSocket", cg.Component)
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(OTAComponent),
+            cv.SplitDefault(
+                CONF_PORT,
+                esp8266=8266,
+                esp32=3232,
+                rp2040=2040,
+                bk72xx=8892,
+                rtl87xx=8892,
+            ): cv.port,
+        }
+    ).extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_port(config[CONF_PORT]))
+
+    await cg.register_component(var, config)

--- a/esphome/components/ota_socket/ota_frontend_socket.cpp
+++ b/esphome/components/ota_socket/ota_frontend_socket.cpp
@@ -93,12 +93,12 @@ void OTAFrontendSocket::handle_() {
   }
 
   ESP_LOGD(TAG, "Starting OTA Update from %s...", this->client_->getpeername().c_str());
-  ota::global_ota_component->do_OTA_session(this);
+  ota::global_ota_component->do_ota_session(this);
 }
 
 ssize_t OTAFrontendSocket::read(uint8_t *buf, size_t len) { return this->client_->read(buf, len); }
 ssize_t OTAFrontendSocket::write(const uint8_t *buf, size_t len) { return this->client_->write(buf, len); }
-void OTAFrontendSocket::closeSession() {
+void OTAFrontendSocket::close_session() {
   this->client_->close();
   this->client_ = nullptr;
 }

--- a/esphome/components/ota_socket/ota_frontend_socket.cpp
+++ b/esphome/components/ota_socket/ota_frontend_socket.cpp
@@ -21,6 +21,8 @@ OTAFrontendSocket::OTAFrontendSocket() {}
 
 void OTAFrontendSocket::set_port(uint16_t port) { this->port_ = port; }
 
+float OTAFrontendSocket::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
+
 void OTAFrontendSocket::setup() {
   server_ = socket::socket_ip(SOCK_STREAM, 0);
   if (server_ == nullptr) {

--- a/esphome/components/ota_socket/ota_frontend_socket.cpp
+++ b/esphome/components/ota_socket/ota_frontend_socket.cpp
@@ -1,0 +1,105 @@
+#include "ota_frontend_socket.h"
+
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/util.h"
+
+#include "esphome/components/ota/ota_component.h"
+#include "esphome/components/md5/md5.h"
+#include "esphome/components/network/util.h"
+
+#include <cerrno>
+#include <cstdio>
+
+namespace esphome {
+namespace ota_socket {
+
+static const char *const TAG = "ota_socket";
+
+OTAFrontendSocket::OTAFrontendSocket() {}
+
+void OTAFrontendSocket::set_port(uint16_t port) { this->port_ = port; }
+
+void OTAFrontendSocket::setup() {
+  server_ = socket::socket_ip(SOCK_STREAM, 0);
+  if (server_ == nullptr) {
+    ESP_LOGW(TAG, "Could not create socket.");
+    this->mark_failed();
+    return;
+  }
+  int enable = 1;
+  int err = server_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket unable to set reuseaddr: errno %d", err);
+    // we can still continue
+  }
+  err = server_->setblocking(false);
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket unable to set nonblocking mode: errno %d", err);
+    this->mark_failed();
+    return;
+  }
+
+  struct sockaddr_storage server;
+
+  socklen_t sl = socket::set_sockaddr_any((struct sockaddr *) &server, sizeof(server), this->port_);
+  if (sl == 0) {
+    ESP_LOGW(TAG, "Socket unable to set sockaddr: errno %d", errno);
+    this->mark_failed();
+    return;
+  }
+
+  err = server_->bind((struct sockaddr *) &server, sizeof(server));
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket unable to bind: errno %d", errno);
+    this->mark_failed();
+    return;
+  }
+
+  err = server_->listen(4);
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket unable to listen: errno %d", errno);
+    this->mark_failed();
+    return;
+  }
+
+  this->dump_config();
+}
+
+void OTAFrontendSocket::dump_config() {
+  ESP_LOGCONFIG(TAG, "Over-The-Air Socket Updates:");
+  ESP_LOGCONFIG(TAG, "  Address: %s:%u", network::get_use_address().c_str(), this->port_);
+}
+
+void OTAFrontendSocket::loop() { this->handle_(); }
+
+void OTAFrontendSocket::handle_() {
+  if (client_ == nullptr) {
+    struct sockaddr_storage source_addr;
+    socklen_t addr_len = sizeof(source_addr);
+    client_ = server_->accept((struct sockaddr *) &source_addr, &addr_len);
+  }
+  if (client_ == nullptr)
+    return;
+
+  int enable = 1;
+  int err = client_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket could not enable tcp nodelay, errno: %d", errno);
+    return;
+  }
+
+  ESP_LOGD(TAG, "Starting OTA Update from %s...", this->client_->getpeername().c_str());
+  ota::global_ota_component->do_OTA_session(this);
+}
+
+ssize_t OTAFrontendSocket::read(uint8_t *buf, size_t len) { return this->client_->read(buf, len); }
+ssize_t OTAFrontendSocket::write(const uint8_t *buf, size_t len) { return this->client_->write(buf, len); }
+void OTAFrontendSocket::closeSession() {
+  this->client_->close();
+  this->client_ = nullptr;
+}
+
+}  // namespace ota_socket
+}  // namespace esphome

--- a/esphome/components/ota_socket/ota_frontend_socket.h
+++ b/esphome/components/ota_socket/ota_frontend_socket.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/ota/ota_frontend.h"
+#include "esphome/components/socket/socket.h"
+
+namespace esphome {
+namespace ota_socket {
+
+/// OTAComponent provides a simple way to integrate Over-the-Air updates into your app using ArduinoOTA.
+class OTAFrontendSocket : public Component, public ota::OTAFrontend {
+ public:
+  OTAFrontendSocket();
+
+  /// Manually set the port OTA should listen on.
+  void set_port(uint16_t port);
+
+  ssize_t read(uint8_t *buf, size_t len) override;
+  ssize_t write(const uint8_t *buf, size_t len) override;
+  void closeSession() override;
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  void setup() override;
+  void dump_config() override;
+  void loop() override;
+
+  uint16_t get_port() const;
+
+ protected:
+  void handle_();
+
+  uint16_t port_;
+
+  std::unique_ptr<socket::Socket> server_;
+  std::unique_ptr<socket::Socket> client_;
+};
+
+}  // namespace ota_socket
+}  // namespace esphome

--- a/esphome/components/ota_socket/ota_frontend_socket.h
+++ b/esphome/components/ota_socket/ota_frontend_socket.h
@@ -21,6 +21,7 @@ class OTAFrontendSocket : public Component, public ota::OTAFrontend {
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
+  float get_setup_priority() const override;
   void setup() override;
   void dump_config() override;
   void loop() override;

--- a/esphome/components/ota_socket/ota_frontend_socket.h
+++ b/esphome/components/ota_socket/ota_frontend_socket.h
@@ -17,7 +17,7 @@ class OTAFrontendSocket : public Component, public ota::OTAFrontend {
 
   ssize_t read(uint8_t *buf, size_t len) override;
   ssize_t write(const uint8_t *buf, size_t len) override;
-  void closeSession() override;
+  void close_session() ;
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)


### PR DESCRIPTION
Draft to split the socket usage from the OTA component.

Usage:

```yaml
ota:
  password: bla
  unprotected_writes: True
ota_socket:
```
